### PR TITLE
Increase Timeout for Start of Round Wait

### DIFF
--- a/src/quests/cognac/tasks/round.ts
+++ b/src/quests/cognac/tasks/round.ts
@@ -38,8 +38,8 @@ export class Round {
           );
           wait(5);
           this.initRetries++;
-          if (this.initRetries === 24) {
-            /* I refuse to wait longer than 2 minutes */
+          if (this.initRetries === 120) {
+            /* I refuse to wait longer than 10 minutes */
             set(CURRENT_STENCH, 0);
           }
         },


### PR DESCRIPTION
It is expected that we may need to wait for a while for the start of the round

If we start the round early, it desyncs everyone and causes issues