### PR TITLE
Fix combat hanging on stench check & write stench to whiteboard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export function main(command?: string): void {
     Clan.join(clan);
     // enter chat
     cliExecute("chat");
+    chatClan("/listen hobopolis", "hobopolis");
     chatClan(`Starting cognac`, "hobopolis");
     engine.run();
   } finally {

--- a/src/lib/combat.ts
+++ b/src/lib/combat.ts
@@ -105,7 +105,6 @@ export class Macro extends LibramMacro {
     return this.externalIf(
       !drunk(),
       Macro.trySkill($skill`Curse of Weaksauce`)
-        .tryItem($item`porquoise-handled sixgun`)
         .trySkill($skill`Micrometeorite`)
         .tryItemsTogether([$item`Time-Spinner`, $item`HOA citation pad`])
         .trySkill($skill`Extract`),
@@ -117,7 +116,11 @@ export class Macro extends LibramMacro {
   }
 
   attackKill(): Macro {
-    return this.stasis().trySingAlong().attack().repeat();
+    return this.stasis()
+      .tryItem($item`porquoise-handled sixgun`)
+      .trySingAlong()
+      .attack()
+      .repeat();
   }
 
   static attackKill(): Macro {
@@ -126,6 +129,7 @@ export class Macro extends LibramMacro {
 
   mortarShell(): Macro {
     return this.stasis()
+      .tryItem($item`porquoise-handled sixgun`)
       .trySingAlong()
       .trySkill($skill`Stuffed Mortar Shell`)
       .tryItem($item`seal tooth`)

--- a/src/lib/gossip.ts
+++ b/src/lib/gossip.ts
@@ -13,7 +13,7 @@ type GossipObject = {
   gameday: number;
 };
 
-const BASE_STENCH_REQUIRED = 8;
+export const BASE_STENCH_REQUIRED = 8;
 export class Gossip {
   players: string[] = [];
   requestingCompost: string[] = [];
@@ -162,6 +162,13 @@ export class Gossip {
   readyToDive(): boolean {
     return (
       parseInt(get(CURRENT_STENCH)) >= BASE_STENCH_REQUIRED + Math.ceil(this.players.length * 1.1)
+    );
+  }
+
+  almostReadyToDive(): boolean {
+    return (
+      parseInt(get(CURRENT_STENCH)) >=
+      BASE_STENCH_REQUIRED + Math.ceil(this.players.length * 1.1) - 2
     );
   }
 

--- a/src/quests/cognac/tasks/pld.ts
+++ b/src/quests/cognac/tasks/pld.ts
@@ -52,6 +52,10 @@ export class PLD {
         post: () => {
           if (get("lastEncounter") === "The Furtivity of My City") {
             print(`Stench level increased to approx ${get(CURRENT_STENCH)}.`);
+            // update whiteboard when close to goal for backwards compatibility
+            if (this.gossip.almostReadyToDive()) {
+              this.gossip.setStench(parseInt(get(CURRENT_STENCH)));
+            }
           }
         },
       },

--- a/src/quests/cognac/tasks/round.ts
+++ b/src/quests/cognac/tasks/round.ts
@@ -34,7 +34,7 @@ export class Round {
         completed: () => get(CURRENT_STENCH) !== "",
         do: () => {
           print(
-            `Waiting for start of next round (someone diving). Retry number ${this.initRetries}`,
+            `Waiting for start of next round (someone diving). Retry number ${this.initRetries} of 120`,
           );
           wait(5);
           this.initRetries++;


### PR DESCRIPTION
Check stench was hanging in combat due to trying to use the six gun twice

Moved sixgun out of stasis as doesn't seem like it belonged. Added sixgun to where stasis is called as appropriate

Also improved message for initial wait to know how long to expect.

Also, also added writing to whiteboard when stench level is near what is desired. This is to improve backward compatibility with folks not using the chat stench tracking. Can take this out later if we want to optimize whiteboard use at that time

**Fix breaking issue of not listening to /hobopolis**