### PR TITLE
Fix how we listen to /hobo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Args, getTasks } from "grimoire-kolmafia";
-import { chatClan, cliExecute, getClanId, myMeat } from "kolmafia";
+import { chatClan, cliExecute, getClanId, myMeat, wait } from "kolmafia";
 import { Clan, get, set } from "libram";
 
 import * as CognacStats from "./lib/cognac";
@@ -53,7 +53,6 @@ export function main(command?: string): void {
   checkGarbo();
   checkClan();
   maybeResetDailyPreferences();
-  resetSessionPreferences();
 
   const cognacTasks = getTasks([
     Prologue,
@@ -76,6 +75,10 @@ export function main(command?: string): void {
     // enter chat
     cliExecute("chat");
     chatClan("/listenon hobopolis", "hobopolis");
+    // after listening to a chat, can get dumped with a backlog of messages
+    // wait for them to come and reset important prefs
+    wait(5);
+    resetSessionPreferences();
     chatClan(`Starting cognac`, "hobopolis");
     engine.run();
   } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export function main(command?: string): void {
     Clan.join(clan);
     // enter chat
     cliExecute("chat");
-    chatClan("/listen hobopolis", "hobopolis");
+    chatClan("/listenon hobopolis", "hobopolis");
     chatClan(`Starting cognac`, "hobopolis");
     engine.run();
   } finally {

--- a/src/prefs/prefs.ts
+++ b/src/prefs/prefs.ts
@@ -38,6 +38,7 @@ export function maybeResetDailyPreferences(): void {
 
 export function resetSessionPreferences(): void {
   set(Properties.CURRENT_STENCH, "");
+  set(Properties.STENCH_TIMER, -1);
 }
 
 export function checkGarbo(): void {

--- a/src/prefs/properties.ts
+++ b/src/prefs/properties.ts
@@ -26,3 +26,4 @@ export const HEAP_ATTEMPTS = daily("heapAttempts");
 export const LAST_STENCH_CHECK = daily("heapAttemptsAtLastStenchCheck");
 export const CURRENT_PLAYERS = daily("currentPlayers");
 export const CURRENT_STENCH = daily("heapStench");
+export const STENCH_TIMER = daily("stenchTimer");

--- a/src/quests/cognac/tasks/heap.ts
+++ b/src/quests/cognac/tasks/heap.ts
@@ -1,5 +1,6 @@
 import { CombatStrategy, Task } from "grimoire-kolmafia";
 import {
+  abort,
   adv1,
   elementalResistance,
   myAdventures,
@@ -54,6 +55,8 @@ const epilogue = (gossip: Gossip) => {
     set(REFUSES_UNTIL_COMPOST, get(REFUSES_UNTIL_COMPOST, 0) - 1);
   } else if (get("lastEncounter") === "The Compostal Service" && gossip.willCompost()) {
     set(REFUSES_UNTIL_COMPOST, 5);
+  } else if (get("lastEncounter") === "Deep Enough to Dive") {
+    abort("At Oscus! Time to reset dungeon and set it up again");
   }
 };
 

--- a/src/quests/cognac/tasks/pld.ts
+++ b/src/quests/cognac/tasks/pld.ts
@@ -1,6 +1,7 @@
 import { CombatStrategy, Task } from "grimoire-kolmafia";
-import { print, wait } from "kolmafia";
+import { abort, print, wait } from "kolmafia";
 import { $location, get } from "libram";
+import { set } from "libram/dist/property";
 
 import { Macro } from "../../../lib/combat";
 import { basicEffects, noncombatEffects } from "../../../lib/effects";
@@ -9,7 +10,7 @@ import { selectBestFamiliar } from "../../../lib/familiar";
 import { Gossip } from "../../../lib/gossip";
 import { getModString } from "../../../lib/modifiers";
 import { capNonCombat } from "../../../lib/preparenoncom";
-import { CURRENT_STENCH } from "../../../prefs/properties";
+import { CURRENT_STENCH, STENCH_TIMER } from "../../../prefs/properties";
 
 export class PLD {
   gossip: Gossip;
@@ -55,6 +56,28 @@ export class PLD {
             // update whiteboard when close to goal for backwards compatibility
             if (this.gossip.almostReadyToDive()) {
               this.gossip.setStench(parseInt(get(CURRENT_STENCH)));
+            }
+            // detect if chatbot is working
+            // this essetnially acts as a delay as it takes time for kol to generate the message and more time for chatbot to parse it
+            if (parseInt(get(CURRENT_STENCH)) === 0) {
+              let stenchTimer = parseInt(get(STENCH_TIMER));
+              if (stenchTimer > 0) {
+                // decrement
+                stenchTimer = stenchTimer - 1;
+                set(STENCH_TIMER, stenchTimer);
+              } else if (stenchTimer === 0) {
+                // error if we get to 0
+                abort(
+                  `Failed to detect stench increase while adv in PLD. Likely something wrong with chatbot script.`,
+                );
+              } else if (stenchTimer === -1) {
+                // first time getting NC this round, set timer
+                set(STENCH_TIMER, 2);
+              }
+            }
+            if (parseInt(get(CURRENT_STENCH)) > 0 && parseInt(get(STENCH_TIMER)) !== -1) {
+              // reset timer
+              set(STENCH_TIMER, -1);
             }
           }
         },


### PR DESCRIPTION
/listen actually toggles... we want to always listen

Also adding abort if we are at oscus. No way to determine if we are at him without going through sewers. Maybe could use whiteboard but not bothered enough to do that atm